### PR TITLE
Fix MySQL connection log

### DIFF
--- a/backend/lambdaFunction/journalLambdafunc/index.js
+++ b/backend/lambdaFunction/journalLambdafunc/index.js
@@ -122,7 +122,7 @@ exports.handler = async (event, context) => {
             return;
         }
         
-        console.log('connected as id ' + connection.threadId + "\n");
+        console.log('connected as id ' + conn.threadId + "\n");
         });
 
     


### PR DESCRIPTION
## Summary
- fix variable name when logging connection thread id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68658fa13c7883279f7f6d215d475d70