### PR TITLE
Add personalized journal dashboard

### DIFF
--- a/journal/dashboard.html
+++ b/journal/dashboard.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Journal</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://www.gstatic.com/firebasejs/10.0.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.0.0/firebase-auth-compat.js"></script>
+</head>
+<body>
+  <div class="container" id="journalContainer">
+    <h1 id="welcome">Welcome</h1>
+    <form id="entryForm">
+      <input type="text" id="entryTitle" placeholder="Title" required>
+      <textarea id="entryText" rows="5" placeholder="Write your thoughts..." required></textarea>
+      <button type="submit">Save Entry</button>
+    </form>
+    <div id="entries"></div>
+    <button onclick="signOutUser()">Sign Out</button>
+  </div>
+
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/journal/dashboard.js
+++ b/journal/dashboard.js
@@ -1,0 +1,65 @@
+// dashboard.js
+const firebaseConfig = {
+  apiKey: "AIzaSyC2YGi_HPjp6edncQMAnSI6XHaRrUWus6o",
+  authDomain: "coffeethoughts-41651.firebaseapp.com",
+  projectId: "coffeethoughts-41651",
+  storageBucket: "coffeethoughts-41651.appspot.com",
+  messagingSenderId: "342424038908",
+  appId: "1:342424038908:web:60bea2fba592d922e79679",
+  measurementId: "G-Y02MZF303B"
+};
+
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+
+function getEntriesKey(uid) {
+  return `journal_entries_${uid}`;
+}
+
+function displayEntries(entries) {
+  const container = document.getElementById('entries');
+  container.innerHTML = '';
+  entries.slice().reverse().forEach(entry => {
+    const div = document.createElement('div');
+    div.className = 'entry';
+    div.innerHTML = `<h3>${entry.title}</h3><p>${entry.text}</p><small>${new Date(entry.date).toLocaleString()}</small>`;
+    container.appendChild(div);
+  });
+}
+
+function loadEntries(uid) {
+  const entries = JSON.parse(localStorage.getItem(getEntriesKey(uid))) || [];
+  displayEntries(entries);
+}
+
+function saveEntry(uid, title, text) {
+  const entries = JSON.parse(localStorage.getItem(getEntriesKey(uid))) || [];
+  entries.push({ title, text, date: new Date().toISOString() });
+  localStorage.setItem(getEntriesKey(uid), JSON.stringify(entries));
+  displayEntries(entries);
+}
+
+auth.onAuthStateChanged(user => {
+  if (!user) {
+    window.location.href = 'index.html';
+    return;
+  }
+  document.getElementById('welcome').textContent = `Welcome back, ${user.displayName || user.email}!`;
+  loadEntries(user.uid);
+});
+
+function signOutUser() {
+  auth.signOut();
+}
+
+document.getElementById('entryForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const title = document.getElementById('entryTitle').value;
+  const text = document.getElementById('entryText').value;
+  const user = auth.currentUser;
+  if (user) {
+    saveEntry(user.uid, title, text);
+    document.getElementById('entryTitle').value = '';
+    document.getElementById('entryText').value = '';
+  }
+});

--- a/journal/index.html
+++ b/journal/index.html
@@ -68,13 +68,9 @@
       const uiConfig = {
         callbacks: {
           signInSuccessWithAuthResult: function(authResult, redirectUrl) {
-            document.getElementById('firebaseui-auth-container').style.display = 'none';
-            document.getElementById('personalNote').style.display = 'block';
-            document.getElementById('noteContent').textContent = "Welcome, " + authResult.user.displayName || "user";
-
-            // Redirect to dashboard.html
-            window.location.href = 'public/dashboard.html';  // Redirect after successful sign-in
-
+            localStorage.setItem('journalUserName', authResult.user.displayName || authResult.user.email);
+            localStorage.setItem('journalUserUid', authResult.user.uid);
+            window.location.href = 'dashboard.html';
             return false;
           },
           

--- a/journal/styles.css
+++ b/journal/styles.css
@@ -223,3 +223,32 @@ h1 {
     opacity: 1;
     visibility: visible;
 }
+
+#journalContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    max-width: 600px;
+}
+
+#journalContainer textarea {
+    resize: vertical;
+}
+
+#entries .entry {
+    background: rgba(255, 255, 255, 0.15);
+    padding: 15px;
+    margin-top: 10px;
+    border-radius: 15px;
+}
+
+#entries .entry h3 {
+    margin-bottom: 8px;
+}
+
+#entries .entry small {
+    display: block;
+    margin-top: 5px;
+    font-size: 0.8em;
+    color: #eee;
+}


### PR DESCRIPTION
## Summary
- add a dashboard page for signed-in users
- store user info in localStorage on login
- redirect to the new dashboard after sign-in
- basic styles and script for saving journal entries in local storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873be76fb6083279c04d5d38f41faed